### PR TITLE
Animate an object with corrected aspect ratio

### DIFF
--- a/hello-webgl-react-typescript/package-lock.json
+++ b/hello-webgl-react-typescript/package-lock.json
@@ -15,6 +15,7 @@
         "@types/node": "^16.11.26",
         "@types/react": "^17.0.43",
         "@types/react-dom": "^17.0.14",
+        "gl-matrix": "^3.4.3",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-scripts": "5.0.0",
@@ -7781,6 +7782,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/gl-matrix": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.3.tgz",
+      "integrity": "sha512-wcCp8vu8FT22BnvKVPjXa/ICBWRq/zjFfdofZy1WSpQZpphblv12/bOQLBC1rMM7SGOFS9ltVmKOHil5+Ml7gA=="
     },
     "node_modules/glob": {
       "version": "7.2.0",
@@ -21668,6 +21674,11 @@
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.1"
       }
+    },
+    "gl-matrix": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.3.tgz",
+      "integrity": "sha512-wcCp8vu8FT22BnvKVPjXa/ICBWRq/zjFfdofZy1WSpQZpphblv12/bOQLBC1rMM7SGOFS9ltVmKOHil5+Ml7gA=="
     },
     "glob": {
       "version": "7.2.0",

--- a/hello-webgl-react-typescript/package.json
+++ b/hello-webgl-react-typescript/package.json
@@ -10,6 +10,7 @@
     "@types/node": "^16.11.26",
     "@types/react": "^17.0.43",
     "@types/react-dom": "^17.0.14",
+    "gl-matrix": "^3.4.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "5.0.0",

--- a/hello-webgl-react-typescript/src/App.tsx
+++ b/hello-webgl-react-typescript/src/App.tsx
@@ -4,10 +4,12 @@ import './App.css';
 import Triangle from './basic/triangle.component';
 import Rectangle from './basic/rectangle.component';
 import Model from './basic/model.component';
+import AnimateComponent from './basic/animate.component';
 
 function App() {
   return (
     <div className="App">
+      <AnimateComponent />
       <Model />
       <Rectangle />
       <Triangle />

--- a/hello-webgl-react-typescript/src/basic/animate.component.tsx
+++ b/hello-webgl-react-typescript/src/basic/animate.component.tsx
@@ -1,0 +1,60 @@
+import React, { useRef, useEffect } from 'react';
+import './basic.component.css';
+import AnimateRenderer from './animate.renderer';
+
+const AnimateComponent = () => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  const requestRef = React.useRef<number>();
+  const timeoutRef = React.useRef<NodeJS.Timeout>();
+
+  useEffect(() => {
+    console.log('Call useEffect');
+    const canvas: HTMLCanvasElement | null = canvasRef.current
+    if (!canvas) {
+      console.error('Sorry! No HTML5 Canvas was found on this page');
+      return;
+    }
+
+    const attributes: WebGLContextAttributes = {
+      antialias: false,
+      preserveDrawingBuffer: true,
+      failIfMajorPerformanceCaveat: true
+    }
+
+    const gl: WebGL2RenderingContext | null = canvas.getContext('webgl2', attributes);
+    if (!gl) {
+      console.error('WebGL2 is not supported by your browser');
+      return;
+    }
+
+    const renderer = new AnimateRenderer(canvas, gl);
+
+    function render(time: DOMHighResTimeStamp) {
+      if (gl != null && canvas != null) {
+        renderer.render(time);
+        requestRef.current = requestAnimationFrame(render);
+      }
+
+      // This allows you to throttle the animation loop
+      // timeoutRef.current = setTimeout(() => {
+      //   requestRef.current = requestAnimationFrame(render);
+      // }, 1000.0);
+    }
+    requestRef.current = requestAnimationFrame(render);
+
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current)
+      }
+      if (requestRef.current) {
+        cancelAnimationFrame(requestRef.current);
+      }
+      renderer.dispose();
+    };
+  }, []);
+
+  return <canvas className="fill-window" ref={canvasRef}/>
+}
+
+export default AnimateComponent;

--- a/hello-webgl-react-typescript/src/basic/animate.renderer.ts
+++ b/hello-webgl-react-typescript/src/basic/animate.renderer.ts
@@ -1,0 +1,160 @@
+import * as shader from './shader'
+import { vertSource, fragSource } from './animate.shaders';
+import Circle2D from './model.circle';
+import { mat4, ReadonlyVec3 } from 'gl-matrix';
+import { viewport, orthoProjection } from './basic.camera';
+
+class AnimateRenderer {
+  canvas: HTMLCanvasElement
+  gl: WebGL2RenderingContext
+
+  program: WebGLProgram | null = null;
+
+  model: Circle2D;
+  vao: WebGLVertexArrayObject | null = null;
+  vbo: WebGLBuffer | null = null;
+  ibo: WebGLBuffer | null = null;
+
+  modelMat4: mat4;
+  viewMat4: mat4;
+  modelViewMat4: mat4;
+  projectionMat4: mat4;
+  modelViewMat4Location: WebGLUniformLocation | null = null;
+  projectionMat4Location: WebGLUniformLocation | null = null;
+
+  constructor(canvas: HTMLCanvasElement, gl: WebGL2RenderingContext) {
+    this.canvas = canvas;
+    this.gl = gl;
+    
+    this.model = new Circle2D(0.5, 10);
+
+    this.modelMat4 = mat4.create();
+    this.viewMat4 = mat4.create();
+    this.modelViewMat4 = mat4.create();
+    this.projectionMat4= mat4.create();
+
+    const eye:    ReadonlyVec3 = [0.0, 0.0, -1.0];
+    const center: ReadonlyVec3 = [0.0, 0.0,  0.0];
+    const up:     ReadonlyVec3 = [0.0, 1.0,  0.0];
+    mat4.lookAt(this.viewMat4, eye, center, up);
+
+    const program = this.program = this.initProgram();
+    if (!program) {
+      // Error log in initProgram
+      return;
+    }
+  }
+  
+  render(time: number) {
+    const gl = this.gl;
+
+    viewport(gl, this.canvas);
+
+    gl?.clear(gl.COLOR_BUFFER_BIT);
+    // gl?.clearColor(0.0, 1.0, 0.0, 1.0);
+    // gl?.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+
+    gl.useProgram(this.program);
+
+    orthoProjection(this.projectionMat4, gl);
+    gl.uniformMatrix4fv(this.projectionMat4Location, false, this.projectionMat4);
+
+    mat4.identity(this.modelMat4);
+    const radianLoop = ((time % 5000) / 5000) * Math.PI * 2;
+    const xPos = this.model.round(0.2 * Math.cos(radianLoop), 3);
+    const yPos = this.model.round(0.2 * Math.sin(radianLoop), 3);
+    mat4.translate(this.modelMat4, this.modelMat4, [xPos * 3, yPos, 0.0]);
+    mat4.rotate(this.modelMat4, this.modelMat4, -radianLoop * 2.0, [0.0, 0.0, 1.0]);
+
+    mat4.multiply(this.modelViewMat4, this.viewMat4, this.modelMat4);
+    gl.uniformMatrix4fv(this.modelViewMat4Location, false, this.modelViewMat4);
+
+    gl.bindVertexArray(this.vao);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this.ibo);
+    gl.drawElements(
+      this.model.getDrawMode(gl),
+      this.model.indices.length,
+      gl.UNSIGNED_SHORT,
+      0
+    );
+    
+    gl.bindVertexArray(null);
+    gl.bindBuffer(gl.ARRAY_BUFFER, null);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, null);
+  }
+
+  dispose() {
+    this.gl.deleteVertexArray(this.vao);
+    this.gl.deleteBuffer(this.vbo);
+    this.gl.deleteBuffer(this.ibo);
+    this.gl.deleteProgram(this.program);
+  }
+
+  initProgram(): WebGLProgram | null {
+    const gl = this.gl;
+
+    const vao: WebGLVertexArrayObject | null = this.vao = gl.createVertexArray();
+    if (!vao) {
+      console.error('Unable to initialize WebGLVertexArrayObject');
+      return null;
+    }
+    gl.bindVertexArray(vao);
+
+    const vbo: WebGLBuffer | null = this.vbo = gl.createBuffer();
+    if (!vbo) {
+      console.error('Unable to initialize vertex WebGLBuffer');
+      return null;
+    }
+    gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
+    gl.bufferData(gl.ARRAY_BUFFER, this.model.vertices, gl.STATIC_DRAW);
+
+    const program: WebGLProgram | null = gl.createProgram();
+    if (!program) {
+      console.error('Could not create program')
+      return null;
+    }
+
+    const vertShader = shader.prepare(gl, gl.VERTEX_SHADER, vertSource());
+    if (!vertShader) {
+      // Error log assumed in prepareShader function
+      return null;
+    }
+    const fragShader = shader.prepare(gl, gl.FRAGMENT_SHADER, fragSource());
+    if (!fragShader) {
+      // Error log assumed in prepareShader function
+      return null;
+    }
+  
+    gl.attachShader(program, vertShader);
+    gl.attachShader(program, fragShader);
+    gl.linkProgram(program);
+    gl.detachShader(program, vertShader);
+    gl.detachShader(program, fragShader);
+    gl.deleteShader(vertShader);
+    gl.deleteShader(fragShader);
+
+    gl.useProgram(program);
+
+    const vaoStride = this.model.FBYTES * this.model.STRIDE;
+    const aVertexPosition: GLint = gl.getAttribLocation(program, 'aVertexPosition');
+    gl.enableVertexAttribArray(aVertexPosition);
+    gl.vertexAttribPointer(aVertexPosition, 3, gl.FLOAT, false, vaoStride, this.model.FBYTES * 0);
+
+    this.modelViewMat4Location = gl.getUniformLocation(program, "uModelView")
+    this.projectionMat4Location = gl.getUniformLocation(program, "uProjection")
+
+    const ibo: WebGLBuffer | null = this.ibo = gl.createBuffer();
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, ibo);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, this.model.indices, gl.STATIC_DRAW);
+
+    gl.bindVertexArray(null);
+    gl.bindBuffer(gl.ARRAY_BUFFER, null);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, null);
+
+    shader.logAttributes(gl, program);
+
+    return program;
+  }
+}
+
+export default AnimateRenderer;

--- a/hello-webgl-react-typescript/src/basic/animate.shaders.ts
+++ b/hello-webgl-react-typescript/src/basic/animate.shaders.ts
@@ -1,0 +1,31 @@
+export const vertSource = () => {
+  return `
+  #version 300 es
+  precision mediump float;
+  
+  in vec3 aVertexPosition;
+
+  uniform mat4 uModelView;
+  uniform mat4 uProjection;
+
+  out vec3 vColor;
+  
+  void main(void) {
+    vColor.bgr = aVertexPosition + 0.5;
+    gl_Position = uProjection * uModelView * vec4(aVertexPosition, 1.0);
+  }`;
+};
+
+export const fragSource = () => {
+  return `
+  #version 300 es
+  precision mediump float;
+  
+  in vec3 vColor;
+
+  out vec4 fragColor;
+  
+  void main(void) {
+    fragColor = vec4(vColor, 1.0);
+  }`;
+};

--- a/hello-webgl-react-typescript/src/basic/basic.camera.ts
+++ b/hello-webgl-react-typescript/src/basic/basic.camera.ts
@@ -1,18 +1,49 @@
+import { mat4 } from 'gl-matrix';
+
 export function viewport(
   gl: WebGL2RenderingContext,
   canvas: HTMLCanvasElement
 ) {
-  canvas.width = canvas.clientWidth;
-  canvas.height = canvas.width * 2.0 / 3.0;
+  const width = canvas.clientWidth;
+  const height = Math.floor(canvas.clientHeight);
 
-  if (canvas.width >= canvas.height) {
-    const aspectRatio = canvas.height / canvas.width;
-    const xOffset = (canvas.width - (canvas.width * aspectRatio)) / 2.0;
-    gl.viewport(xOffset, 0, canvas.width * aspectRatio, canvas.height);
+  if (gl.canvas.width != width || gl.canvas.height != height) {
+    canvas.width = width;
+    canvas.height = height;
+    gl.viewport(0, 0, width, height);
   }
-  else if (canvas.width < canvas.height) {
-    const aspectRatio = canvas.width / canvas.height;
-    const yOffset = (canvas.height - (canvas.height * aspectRatio)) / 2.0;
-    gl.viewport(0, yOffset, canvas.width, canvas.height * aspectRatio);
+}
+
+/**
+ * Create a camera projection that optimizes for viewing models
+ * in mobile and desktop environments. The camera space is
+ * normalized to [-1.0, 1.0].
+ *
+ * If the aspect ratio of the viewer favors the height or width,
+ * this projection will attempt to alwasy support visibility.
+ * If the width is greater than the height, all models at location
+ * 1.0 will be visible and there will be extra space available in
+ * width direction.
+ *
+ * @param out The projection matrix that will be written to.
+ */
+export function orthoProjection(
+  out: mat4,
+  gl: WebGL2RenderingContext
+) {
+  const left = -1;
+  const right = 1;
+  const bottom = 1;
+  const top = -1;
+  const near = -1;
+  const far = 1;
+  mat4.ortho(out, left, right, bottom, top, near, far)
+
+  if (gl.canvas.clientWidth > gl.canvas.clientHeight) {
+    const scaleX = gl.canvas.clientHeight / gl.canvas.clientWidth;
+    mat4.scale(out, out, [scaleX, 1.0, 1.0])
+  } else {
+    const scaleY = gl.canvas.clientWidth / gl.canvas.clientHeight;
+    mat4.scale(out, out, [1.0, scaleY, 1.0])
   }
 }


### PR DESCRIPTION
When starting to animate, the right and left side of my objects were being clipped. This made me believe the `gl.viewport` is not a good place to handle aspect ratio scaling. Unless there is a better approach than what I was taking.

So I also introduced an orthographic projection. The viewport can create a "canvas" space. The canvas does not care about the objects or models. It is concerned with resolution.

The orthographic projection was ideal because you can easily scale the matrix to fit the aspect ratio. I also decided _scale to fit 1.0_. Meaning, if you're on a mobile device you will see all world objects between [-1,1], even though there is extra height available. If you're on a desktop, the top and bottom will not clip objects beyond +-1.0 either.

With animation frames, I'm getting interested in creating fades between buffers. Maybe that's what I'd do next, but also want to create more interesting objects.

It's not that exciting but this is what it does

https://user-images.githubusercontent.com/3021882/161308350-cb1af3e7-358f-49a4-b0e9-85421850fa88.mp4

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kmadsen/webgl/4)
<!-- Reviewable:end -->
